### PR TITLE
Align newsletter and carbonads box by removing max-width

### DIFF
--- a/resources/assets/css/front/components/carbon.scss
+++ b/resources/assets/css/front/components/carbon.scss
@@ -1,5 +1,5 @@
 #carbonads {
-    @apply .flex .flex-col  .content-center .self-start .bg-white .border-2 .rounded .mb-4 .py-4 .px-6 .mt-4 .max-w-sm .text-xs .leading-normal .text-grey-dark;
+    @apply .flex .flex-col  .content-center .self-start .bg-white .border-2 .rounded .mb-4 .py-4 .px-6 .mt-4 .text-xs .leading-normal .text-grey-dark;
 }
 
 .carbon-wrap {

--- a/resources/assets/css/front/components/newsletter.scss
+++ b/resources/assets/css/front/components/newsletter.scss
@@ -1,3 +1,3 @@
 .newsletter-box {
-    @apply .flex .flex-col .content-center .self-start .bg-white .border-2 .rounded .mb-4 .py-4 .px-4 .mt-4 .max-w-md .text-xs .leading-normal .text-grey-dark;
+    @apply .flex .flex-col .content-center .self-start .bg-white .border-2 .rounded .mb-4 .py-4 .px-4 .mt-4 .text-xs .leading-normal .text-grey-dark;
 }


### PR DESCRIPTION
By removing max-width classes the carbonads and newsletter box get aligned more properly in tablet and mobile view. 

