### PR TITLE
Avoid layout jumps in sidebar

### DIFF
--- a/resources/assets/css/front/components/carbon.scss
+++ b/resources/assets/css/front/components/carbon.scss
@@ -1,10 +1,10 @@
 #carbonads {
-    @apply .flex .flex-col  .content-center .self-start .bg-white .border-2 .rounded .mb-4 .py-4 .px-6 .mt-4 .text-xs .leading-normal .text-grey-dark;
+    @apply .flex .flex-col .content-center .self-start .bg-white .border-2 .rounded .mb-4 .py-4 .px-6 .mt-4 .text-xs .leading-normal .text-grey-dark;
+    animation: carbon .1s linear;
 }
 
 .carbon-wrap {
     @apply .flex .flex-col .items-center;
-
 }
 
 #carbonads a {
@@ -15,6 +15,11 @@
     color: config('colors.blue');
 }
 
+.carbon-img {
+    @apply .block;
+    min-height: 100px;
+}
+
 .carbon-text {
     @apply .mt-2 mb-2;
 }
@@ -22,4 +27,9 @@
 .carbon-poweredby {
     font-size: 9px;
     text-transform: uppercase;
+}
+
+@keyframes carbon {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }

--- a/resources/views/front/layouts/master.blade.php
+++ b/resources/views/front/layouts/master.blade.php
@@ -27,8 +27,8 @@
         </main>
 
         <div class="lg:w-1/4">
-            @include('front.layouts._partials.carbon')
             @include('front.layouts._partials.newsletter')
+            @include('front.layouts._partials.carbon')
         </div>
 
 


### PR DESCRIPTION
- Moves the ad block under the newsletter block so the newsletter block doesn't get bumped down on load
- Adds a very slight fade to the ad block so it's not too sudden
- Give the Carbon image a min height so the space is filled before the image is loaded