### PR TITLE
Clean up posts list

### DIFF
--- a/resources/views/front/posts/_partials/listItem.blade.php
+++ b/resources/views/front/posts/_partials/listItem.blade.php
@@ -3,12 +3,12 @@
         {{ $post->formatted_title }}
     </a>
     <div class="flex items-center text-xs pt-2 mb-2">
-        <span class="text-grey">
+        <time datetime="{{ $post->publish_date->format(DateTime::ATOM) }}" class="text-grey">
             {{ $post->publish_date->format('F d, Y') }}
-        </span>
+        </time>
 
         @if ($post->tags->count())
-            <span class="text-grey-light">&nbsp; | &nbsp;</span>
+            <span class="text-grey">&nbsp; | &nbsp;</span>
         @endif
 
         @include('front.posts._partials.tags')

--- a/resources/views/front/posts/_partials/listItem.blade.php
+++ b/resources/views/front/posts/_partials/listItem.blade.php
@@ -2,13 +2,13 @@
     <a href="{{ action('Front\PostsController@detail', [$post->slug]) }}">
         {{ $post->formatted_title }}
     </a>
-    <div class="flex content-center text-xs pt-2 mb-2">
-        <div class="flex flex-col justify-center text-grey">
+    <div class="flex items-center text-xs pt-2 mb-2">
+        <span class="text-grey">
             {{ $post->publish_date->format('F d, Y') }}
-        </div>
+        </span>
 
         @if ($post->tags->count())
-            <div class="flex flex-col justify-center">&nbsp; | &nbsp;</div>
+            <span class="text-grey-light">&nbsp; | &nbsp;</span>
         @endif
 
         @include('front.posts._partials.tags')

--- a/resources/views/front/posts/detail.blade.php
+++ b/resources/views/front/posts/detail.blade.php
@@ -19,7 +19,7 @@
     <h1>{{ $post->formatted_title }}</h1>
 
     <div class="text-grey-darker text-sm pb-6 border-b text-grey">
-        Posted on {{ $post->publish_date }} | {{ $post->author }}
+        Posted on <time datetime="{{ $post->publish_date->format(DateTime::ATOM) }}">{{ $post->publish_date }}</time> | {{ $post->author }}
     </div>
 
     <div class="pt-4 post-content">


### PR DESCRIPTION
- Remove unnecessary layout classes
- Lighten the seperator so it doesn't steal the show anymore
- Wrap publish dates in `time` elements

<img width="653" alt="screen shot 2017-11-20 at 10 54 32" src="https://user-images.githubusercontent.com/1561079/33012443-388f667a-cde1-11e7-9cad-5b813a35f51d.png">
