### PR TITLE
simplify getTextAttribute accessor

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -44,11 +44,9 @@ class Post extends BaseModel implements Feedable
         $query->where('published', true);
     }
 
-    public function getTextAttribute()
+    public function getTextAttribute($original)
     {
-        $parseDown = new Parsedown();
-
-        return $parseDown->text($this->getOriginal('text'));
+        return (new Parsedown())->text($original);
     }
 
     public function getMarkdownAttribute()


### PR DESCRIPTION
There is no need in getOriginal() method cause the original value is already passed to the accessor as official docs says.