### PR TITLE
fix bug in purgecss extractor

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -46,7 +46,7 @@ mix
                     {
                         extractor: class {
                             static extract(content) {
-                                return content.match(/[A-z0-9-:\/]+/g)
+                                return content.match(/[A-z0-9-:\/]+/g) || []
                             }
                         },
                         extensions: ['html', 'js', 'php', 'vue'],


### PR DESCRIPTION
I was using part of this purgecss config for a project of mine, and i kept getting an `Error: The extractor has failed to extract the selectors.` error. Turns out the extractor returns `null` when a file has no selectors, which causes purgecss to fail. Returning an empty array fixes this