### PR TITLE
Fixed needless margin on small devices

### DIFF
--- a/resources/views/front/layouts/master.blade.php
+++ b/resources/views/front/layouts/master.blade.php
@@ -23,7 +23,7 @@
     <div class="flex flex-col lg:flex-row">
 
 
-        <main class="lg:w-3/4 mr-4">
+        <main class="lg:w-3/4 lg:mr-4">
             @yield('content')
         </main>
 


### PR DESCRIPTION
On small devices the content is disturbed by a margin on the right site. However, this margin is only required on large screens.

![screen shot 2018-02-14 at 10 33 57](https://user-images.githubusercontent.com/2338402/36202391-ed6f69e2-1183-11e8-9285-bdc1a22fae09.png)
