### PR TITLE
Upgrade version of Commanmark Highlighter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "laravel/scout": "^3.0",
         "laravel/tinker": "^1.0",
         "ohdearapp/nova-ohdear-tool": "^1.0",
-        "spatie/commonmark-highlighter": "^0.1.0",
+        "spatie/commonmark-highlighter": "^1.0",
         "spatie/laravel-backup": "^6.0",
         "spatie/laravel-csp": "^2.0",
         "spatie/laravel-feed": "^2.0",


### PR DESCRIPTION
I noticed that if I provide the **js(javascript)** code-block in the post while viewing it goes in infinite loop.

 Check Issue https://github.com/spatie/commonmark-highlighter/issues/3

It seems commanmark highlighter's version needs to be updated. I have tested this, after upgrading it works perfectly. 

https://github.com/spatie/murze.be/blob/327ba8cf3f9c98d98b9b4d6a8f62913bd3d8096b/composer.json#L35

Thanks