### PR TITLE
Add default canonical link

### DIFF
--- a/resources/views/front/layouts/partials/head.blade.php
+++ b/resources/views/front/layouts/partials/head.blade.php
@@ -14,6 +14,8 @@
 @endif
 @if($canonical ?? null)
 <link rel="canonical" href="{{ $canonical }}" />
+@else
+<link rel="canonical" href="{{ url()->current() }}" />
 @endif
 @include('feed::links')
 @include('front.layouts.partials.seo')

--- a/tests/Feature/CanonicalTest.php
+++ b/tests/Feature/CanonicalTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\Post;
+
+use function Pest\Laravel\get;
+
+it('adds a self-referencing canonical pointing to the clean url', function () {
+    Post::factory()->create([
+        'published' => true,
+        'publish_date' => now()->subDay(),
+    ]);
+
+    get('/')
+        ->assertOk()
+        ->assertSee('<link rel="canonical" href="'.url('/').'" />', false);
+});
+
+it('strips the query string from the self-referencing canonical', function () {
+    Post::factory()->count(25)->create([
+        'published' => true,
+        'publish_date' => now()->subDay(),
+    ]);
+
+    get('/?page=2')
+        ->assertOk()
+        ->assertSee('<link rel="canonical" href="'.url('/').'" />', false)
+        ->assertDontSee('<link rel="canonical" href="'.url('/?page=2').'" />', false);
+});
+
+it('keeps an explicit canonical for link posts pointing to the external url', function () {
+    $post = Post::factory()->create([
+        'published' => true,
+        'publish_date' => now()->subDay(),
+        'original_content' => false,
+        'external_url' => 'https://example.com/some-article',
+    ]);
+
+    get($post->url)
+        ->assertOk()
+        ->assertSee('<link rel="canonical" href="https://example.com/some-article" />', false);
+});


### PR DESCRIPTION
Adds a default self-referencing canonical link for pages that do not provide an explicit canonical URL. Keeps explicit canonicals intact, including external canonical URLs for link posts. Adds feature coverage for the home page canonical, query-string stripping, and explicit link-post canonicals.\n\nTests: ./vendor/bin/pest tests/Feature/CanonicalTest.php