### PR TITLE
Bump GitHub Actions off deprecated Node runtimes

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -16,6 +16,6 @@ jobs:
         uses: aglipanci/laravel-pint-action@2.0.0
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Fix styling

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,7 +45,7 @@ jobs:
                     COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
             -   name: Cache yarn dependencies
-                uses: actions/cache@v4
+                uses: actions/cache@v6
                 with:
                     path: node_modules
                     key: yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/tia-baseline.yml
+++ b/.github/workflows/tia-baseline.yml
@@ -37,7 +37,7 @@ jobs:
                     COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
             -   name: Cache yarn dependencies
-                uses: actions/cache@v4
+                uses: actions/cache@v6
                 with:
                     path: node_modules
                     key: yarn-${{ hashFiles('yarn.lock') }}
@@ -59,7 +59,7 @@ jobs:
                     REDIS_PORT: ${{ job.services.redis.ports[6379] }}
 
             -   name: Publish baseline
-                uses: actions/upload-artifact@v4
+                uses: actions/upload-artifact@v7
                 with:
                     name: pest-tia-baseline
                     path: ${{ env.TIA_DIR }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -21,7 +21,7 @@ jobs:
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: main
           commit_message: Update CHANGELOG


### PR DESCRIPTION
CI was warning that `actions/cache@v4` targets Node.js 20 and is being forced onto Node.js 24. Bumped it to v6, and while checking the other actions found `actions/upload-artifact@v4` (node20) and `stefanzweifel/git-auto-commit-action@v4` (node16) in the same state, so those went to v7 as well. `actions/checkout@v6` and `shivammathur/setup-php@v2` already run on node24; the pint and changelog actions are Docker-based.

No input changes were needed at any call site, and upload-artifact's storage backend is unchanged since v4, so the TIA baseline download in run-tests still resolves.