### PR TITLE
Merge sitewide SEO tags instead of replacing them

### DIFF
--- a/resources/views/front/layouts/app.blade.php
+++ b/resources/views/front/layouts/app.blade.php
@@ -1,4 +1,4 @@
-@props(['wide' => false, 'title' => null, 'canonical' => null, 'hideBio' => false])
+@props(['wide' => false, 'title' => null, 'description' => null, 'canonical' => null, 'hideBio' => false])
 
 @include('front.layouts.partials.head')
 

--- a/resources/views/front/layouts/partials/head.blade.php
+++ b/resources/views/front/layouts/partials/head.blade.php
@@ -5,7 +5,7 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="mobile-web-app-capable" content="yes">
-<link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 <link href="https://github.com/freekmurze" rel="me">
 @if($title ?? null)
 <title>{{ $title }} - Freek Van der Herten's blog on Laravel, PHP and AI</title>

--- a/resources/views/front/layouts/partials/seo.blade.php
+++ b/resources/views/front/layouts/partials/seo.blade.php
@@ -1,37 +1,15 @@
-@if(isset($seo))
+@php
+    $pageDescription = $description ?? 'Freek Van der Herten writes about Laravel, PHP and AI. Co-owner of Spatie, maintainer of 300+ open source packages with over 2 billion downloads.';
+@endphp
+
+<meta name="description" content="{{ $pageDescription }}">
+
+<meta property="og:site_name" content="freek.dev">
+<meta property="og:locale" content="en_US">
+<meta property="og:description" content="{{ $pageDescription }}">
+<meta property="og:url" content="{{ url()->current() }}">
+<meta name="twitter:description" content="{{ $pageDescription }}">
+
+@isset($seo)
     {{ $seo }}
-@else
-
-    <meta name="description" content="Freek Van der Herten writes about Laravel, PHP and AI. Co-owner of Spatie, maintainer of 300+ open source packages with over 2 billion downloads.">
-
-    <meta property="og:site_name" content="freek.dev">
-    <meta property="og:locale" content="en_US">
-    <meta property="og:description" content="Freek Van der Herten writes about Laravel, PHP and AI. Co-owner of Spatie, maintainer of 300+ open source packages with over 2 billion downloads.">
-    <meta property="og:url" content="{{ request()->fullUrl() }}">
-    {{--
-    <script type='application/ld+json'>
-    {
-        "@context":"http:\/\/schema.org",
-        "@type":"WebSite",
-        "@id":"#website",
-        "url":"https:\/\/freek.dev\/",
-        "name":"freek.dev",
-        "alternateName":"A blog on modern PHP and Laravel"
-    }
-
-    </script>
-    --}}
-
-    {{--
-    <script type='application/ld+json'>
-    {
-        "@context":"http:\/\/schema.org",
-        "@type":"Person",
-        "sameAs":["https:\/\/x.com\/freekmurze"],
-        "@id":"#person",
-        "name":"Freek Van der Herten"
-    }
-
-    </script>
-    --}}
-@endif
+@endisset

--- a/resources/views/front/pages/newsletter/archive-show.blade.php
+++ b/resources/views/front/pages/newsletter/archive-show.blade.php
@@ -4,7 +4,6 @@
         <meta property="og:type" content="article">
         <meta property="og:title" content="{{ $newsletterCampaign->name }}">
         <meta property="article:published_time" content="{{ $newsletterCampaign->sent_at->toIso8601String() }}">
-        <meta name="twitter:card" content="summary">
         <meta name="twitter:title" content="{{ $newsletterCampaign->name }}">
     </x-slot>
 

--- a/resources/views/front/posts/show.blade.php
+++ b/resources/views/front/posts/show.blade.php
@@ -1,4 +1,4 @@
-<x-app-layout :title="$post->title" :canonical="$canonical ?? $post->external_url">
+<x-app-layout :title="$post->title" :description="$post->plain_text_excerpt" :canonical="$canonical ?? $post->external_url">
     <x-post-header :post="$post" class="mb-8" :showTags="true">
 
         {!! $post->html_with_utm !!}
@@ -54,12 +54,8 @@
     @endunless
 
     <x-slot name="seo">
-        <meta property="og:site_name" content="freek.dev"/>
-        <meta property="og:locale" content="en_US"/>
         <meta property="og:type" content="article"/>
-        <meta property="og:url" content="{{ request()->fullUrl() }}"/>
         <meta property="og:title" content="{{ $post->title }} | freek.dev"/>
-        <meta property="og:description" content="{{ $post->plain_text_excerpt }}"/>
 
         @foreach($post->tags as $tag)
             <meta property="article:tag" content="{{ $tag->name }}"/>
@@ -67,7 +63,6 @@
 
         <meta property="article:published_time" content="{{ $post->publish_date?->toIso8601String() }}"/>
         <meta property="og:updated_time" content="{{ $post->updated_at->toIso8601String() }}"/>
-        <meta name="twitter:description" content="{{ $post->plain_text_excerpt }}"/>
         <meta name="twitter:title" content="{{ $post->title }} | freek.dev"/>
         <meta name="twitter:site" content="@freekmurze"/>
         <meta name="twitter:creator" content="@freekmurze"/>

--- a/tests/Feature/SeoMetaTest.php
+++ b/tests/Feature/SeoMetaTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Models\Post;
+
+use function Pest\Laravel\get;
+
+function postWithKnownExcerpt(array $attributes = []): Post
+{
+    return Post::factory()->create([
+        'published' => true,
+        'publish_date' => now()->subDay(),
+        'original_content' => true,
+        'text' => 'A short and very recognisable excerpt.',
+        ...$attributes,
+    ]);
+}
+
+it('renders a meta description on a post page', function () {
+    $post = postWithKnownExcerpt();
+
+    get($post->url)
+        ->assertOk()
+        ->assertSee('<meta name="description" content="'.$post->plain_text_excerpt.'">', false);
+});
+
+it('keeps the site wide og tags on a page that fills the seo slot', function () {
+    $post = postWithKnownExcerpt();
+
+    get($post->url)
+        ->assertOk()
+        ->assertSee('<meta property="og:site_name" content="freek.dev">', false)
+        ->assertSee('<meta property="og:locale" content="en_US">', false)
+        ->assertSee('<meta property="og:type" content="article"/>', false);
+});
+
+it('does not render duplicate og description or og url tags on a post page', function () {
+    $post = postWithKnownExcerpt();
+
+    $content = get($post->url)->assertOk()->getContent();
+
+    expect(substr_count($content, '<meta property="og:description"'))->toBe(1)
+        ->and(substr_count($content, '<meta property="og:url"'))->toBe(1)
+        ->and(substr_count($content, '<meta name="description"'))->toBe(1);
+});
+
+it('falls back to the site wide description on a page without its own description', function () {
+    postWithKnownExcerpt();
+
+    get('/')
+        ->assertOk()
+        ->assertSee('<meta name="description" content="Freek Van der Herten writes about Laravel, PHP and AI.', false);
+});
+
+it('points the favicon at the site root so it resolves on nested urls', function () {
+    $post = postWithKnownExcerpt();
+
+    get($post->url)
+        ->assertOk()
+        ->assertSee('<link rel="shortcut icon" href="/favicon.ico"', false);
+});
+
+it('strips the query string from og url', function () {
+    Post::factory()->count(25)->create([
+        'published' => true,
+        'publish_date' => now()->subDay(),
+    ]);
+
+    get('/?page=2')
+        ->assertOk()
+        ->assertSee('<meta property="og:url" content="'.url('/').'">', false);
+});


### PR DESCRIPTION
The seo partial was an `@if/@else`, so any page filling the `seo` slot dropped every sitewide tag: post pages rendered no meta description at all, and newsletter archive pages also lost `og:url`, `og:site_name` and `og:locale`. It now always renders the defaults and appends the slot, with pages overriding the description through a new `description` prop on `x-app-layout`, and the tags the defaults provide were removed from the post and newsletter slots so the merge does not duplicate them.

Also points the favicon at `/favicon.ico` (it resolved to `/posts/favicon.ico` on nested urls), drops the newsletter archive `twitter:card` that conflicted with the `summary_large_image` RenderOgImageMiddleware appends unconditionally, and switches `og:url` to `url()->current()` so it matches the canonical. Despite the branch name, this adds no dependency: `laravel/head` would fix this class of bug with its field-by-field merge, but it is at v0.1.0, so these fixes stand on their own for now.